### PR TITLE
Fix for appending null req vars

### DIFF
--- a/src/lua/api-gateway/tracking/RequestTrackingManager.lua
+++ b/src/lua/api-gateway/tracking/RequestTrackingManager.lua
@@ -229,18 +229,16 @@ local function matchVarsWithDomains(vars, domains, cache, separator)
         -- ngx.log(ngx.DEBUG, "VAR " , tostring(i))
         local variableManager = ngx.apiGateway.tracking.variableManager
         v = variableManager:getRequestVariable(vars[i], cache)
-        if v ~= nil then
-            -- ngx.log(ngx.DEBUG, "VAL=", v)
-            d = domains[i]
-            -- ngx.log(ngx.DEBUG, "DOMAIN=", d)
-            if (d == "*") then
-                str = str .. v .. separator
-            else
-                if d ~= v then
-                    return false, str
-                end
-                str = str .. v .. separator
+        -- ngx.log(ngx.DEBUG, "VAL=", v)
+        d = domains[i]
+        -- ngx.log(ngx.DEBUG, "DOMAIN=", d)
+        if (d == "*") then
+            str = str .. v .. separator
+        else
+            if d ~= v then
+                return false, str
             end
+            str = str .. tostring(v) .. separator
         end
     end
     return true, str

--- a/src/lua/api-gateway/tracking/RequestTrackingManager.lua
+++ b/src/lua/api-gateway/tracking/RequestTrackingManager.lua
@@ -229,16 +229,18 @@ local function matchVarsWithDomains(vars, domains, cache, separator)
         -- ngx.log(ngx.DEBUG, "VAR " , tostring(i))
         local variableManager = ngx.apiGateway.tracking.variableManager
         v = variableManager:getRequestVariable(vars[i], cache)
-        -- ngx.log(ngx.DEBUG, "VAL=", v)
-        d = domains[i]
-        -- ngx.log(ngx.DEBUG, "DOMAIN=", d)
-        if (d == "*") then
-            str = str .. v .. separator
-        else
-            if d ~= v then
-                return false, str
+        if v ~= nil then
+            -- ngx.log(ngx.DEBUG, "VAL=", v)
+            d = domains[i]
+            -- ngx.log(ngx.DEBUG, "DOMAIN=", d)
+            if (d == "*") then
+                str = str .. v .. separator
+            else
+                if d ~= v then
+                    return false, str
+                end
+                str = str .. v .. separator
             end
-            str = str .. v .. separator
         end
     end
     return true, str


### PR DESCRIPTION
Earlier today, an issue was opened saying that:
`failed to run log_by_lua*: ...y/lualib/api-gateway/tracking/RequestTrackingManager.lua:242: attempt to concatenate local 'v' **(a nil value)**`

This is a quick and dirty fix for it. 
@ddragosd, @cristianconstantin ping. 
