### PR TITLE
Fix ngx.req.get_body_data() issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+*.iml
 target/**

--- a/src/lua/api-gateway/tracking/factory.lua
+++ b/src/lua/api-gateway/tracking/factory.lua
@@ -38,29 +38,25 @@ local cjson = require "cjson"
 local function _API_POST_Handler()
     local trackingManager = ngx.apiGateway.tracking.manager
     if ( ngx.req.get_method() == "POST" ) then
+       ngx.req.read_body()
+
        local json_string = ngx.req.get_body_data()
 
        -- Check http://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxreqget_body_data for details
        if (json_string == nil) then
-           ngx.log(ngx.WARN, "ngx.req.get_body_data() returned nil, maybe the request body has not been read yet; retrying")
-           ngx.req.read_body()
-           json_string = ngx.req.get_body_data()
+           ngx.log(ngx.WARN, "ngx.req.get_body_data() returned nil, maybe the request body has been read into disk files; retrying")
 
-           if (json_string == nil) then
-               ngx.log(ngx.WARN, "ngx.req.get_body_data() returned nil, maybe the request body has been read into disk files; retrying")
+           local body_file_name = ngx.req.get_body_file()
 
-               local body_file_name = ngx.req.get_body_file()
+           if (body_file_name == nil) then
+               ngx.log(ngx.WARN, "ngx.req.get_body_file() returned nil, maybe the request body has not been read or has been read into memory")
+           else
+               ngx.log(ngx.DEBUG, "ngx.req.get_body_file() returned ", body_file_name)
 
-               if (body_file_name == nil) then
-                   ngx.log(ngx.WARN, "ngx.req.get_body_file() returned nil, maybe the request body has not been read or has been read into memory")
-               else
-                   ngx.log(ngx.DEBUG, "ngx.req.get_body_file() returned ", body_file_name)
+               local body_file = io.open(body_file_name, "rb")
 
-                   local body_file = io.open(body_file_name, "rb")
-
-                   json_string = body_file:read("*all")
-                   ngx.log(ngx.DEBUG, "Read '", json_string, "' from ", body_file_name)
-               end
+               json_string = body_file:read("*all")
+               ngx.log(ngx.DEBUG, "Read '", json_string, "' from ", body_file_name)
            end
        end
 

--- a/src/lua/api-gateway/tracking/factory.lua
+++ b/src/lua/api-gateway/tracking/factory.lua
@@ -37,9 +37,33 @@ local cjson = require "cjson"
 --   POST /tracking
 local function _API_POST_Handler()
     local trackingManager = ngx.apiGateway.tracking.manager
-    ngx.req.read_body()
     if ( ngx.req.get_method() == "POST" ) then
        local json_string = ngx.req.get_body_data()
+
+       -- Check http://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxreqget_body_data for details
+       if (json_string == nil) then
+           ngx.log(ngx.WARN, "ngx.req.get_body_data() returned nil, maybe the request body has not been read yet; retrying")
+           ngx.req.read_body()
+           json_string = ngx.req.get_body_data()
+
+           if (json_string == nil) then
+               ngx.log(ngx.WARN, "ngx.req.get_body_data() returned nil, maybe the request body has been read into disk files; retrying")
+
+               local body_file_name = ngx.req.get_body_file()
+
+               if (body_file_name == nil) then
+                   ngx.log(ngx.WARN, "ngx.req.get_body_file() returned nil, maybe the request body has not been read or has been read into memory")
+               else
+                   ngx.log(ngx.DEBUG, "ngx.req.get_body_file() returned ", body_file_name)
+
+                   local body_file = io.open(body_file_name, "rb")
+
+                   json_string = body_file:read("*all")
+                   ngx.log(ngx.DEBUG, "Read '", json_string, "' from ", body_file_name)
+               end
+           end
+       end
+
        local success, err, forcible = trackingManager:addRule(json_string)
        if ( success ) then
           ngx.say('{"result":"success"}')


### PR DESCRIPTION
The Lua code which accesses the body of POST requests does not handle all possible scenarios. It attempts to read the body from memory and expects it to be available. However, the documentation clearly states otherwise: http://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxreqget_body_data

According to http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size "_In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file._". The default is 8k. We've tested with a 10k POST request and can confirm that the request body is written to a temporary disk file. Apparently it doesn't do that when the server is not under load, at least from what we could see in the log files; maybe due to NGINX internal memory management logic.

This pull request attempts to solve the problem by properly addressing documented `ngx.req.get_body_data()` usage scenarios.
