### PR TITLE
Return all entries from rules dictionary

### DIFF
--- a/src/lua/api-gateway/tracking/RequestTrackingManager.lua
+++ b/src/lua/api-gateway/tracking/RequestTrackingManager.lua
@@ -170,7 +170,7 @@ function _M:getRulesForType(rule_type)
     -- docs: http://wiki.nginx.org/HttpLuaModule#ngx.shared.DICT.get_keys
     -- will return a max of 1024 keys
     cached_rules[rule_type] = {}
-    local keys = dict:get_keys()
+    local keys = dict:get_keys(0)
     local val_string, val, data, domain, expire_at_utc, id, meta, decode_ok
     local i, domain_split_idx
     for i, key in pairs(keys) do


### PR DESCRIPTION
By default the method get_keys returns 1024 keys . 

`syntax: keys = ngx.shared.DICT:get_keys(max_count?)`

When the <max_count> argument is given the value 0, then all the keys will be returned even if there are more than 1024 keys in the dictionary.